### PR TITLE
Bugfix/removing user from default wall causes bugs on frontend

### DIFF
--- a/src/webapp/src/client/app/wall/discover-walls/list/list.html
+++ b/src/webapp/src/client/app/wall/discover-walls/list/list.html
@@ -51,7 +51,7 @@
             <div class="col-xs-4 col-lg-3 discover-walls-card-action nopadding"
                  ng-init="isWallOwner = vm.isCurrentUserWallOwner(wall.moderators)">
 
-                <a ng-if="wall.type === 'Main' || isWallOwner"
+                <a ng-if="(wall.type === 'Main' && wall.isFollowing)|| isWallOwner"
                    class="nc-btn nc-btn-danger wall-unfollow-disabled" 
                    ng-click="vm.toggleFollowWall(wall)" 
                    translate-attr-title="wall.unfollow" 
@@ -70,6 +70,18 @@
                     <span ng-if="!wall.isLoading" 
                           class="glyphicon glyphicon-plus"></span><span translate="wall.follow"></span>
                 </a>
+
+                <a ng-if="!wall.isFollowing && wall.type === 'Main' && !isWallOwner" 
+                    class="nc-btn nc-btn-default" 
+                    ng-click="vm.toggleFollowWall(wall)" 
+                    translate-attr-title="wall.follow" 
+                    data-test-id="follow-wall-button" 
+                    translate>
+                 <circle-spinner ng-if="wall.isLoading"></circle-spinner>
+                 <span ng-if="!wall.isLoading" 
+                       class="glyphicon glyphicon-plus"></span><span translate="wall.follow"></span>
+                </a>
+
                 <a ng-if="wall.isFollowing && wall.type !== 'Main' && !isWallOwner" 
                    class="nc-btn nc-btn-danger" 
                    ng-click="vm.toggleFollowWall(wall)" 

--- a/src/webapp/src/client/app/wall/menu-navigation/menu-navigation.html
+++ b/src/webapp/src/client/app/wall/menu-navigation/menu-navigation.html
@@ -1,4 +1,4 @@
-<ul id="walls-sidebar-nav" ng-if="vm.wallServiceData.wallList.length && !vm.wallServiceData.isWallListLoading" 
+<ul id="walls-sidebar-nav" ng-if="!vm.wallServiceData.isWallListLoading" 
     class="nav nav-sidebar first-level wall-menu-navigation-container">
   <li data-test-id="sidebar-group-walls">
      <span class="glyphicon glyphicon-show-thumbnails"></span><span translate="wall.wallList"></span>


### PR DESCRIPTION
Fixed a bug, where once the user somehow has no followed walls, the walls component on sidebar disappears thus disabling user from discovering and joining walls.
Also fixed another issue of 'Follow' button not showing on main wall when user is not following it.